### PR TITLE
bring back the missing last author

### DIFF
--- a/_posts/2022-07-20-borzunov22a.md
+++ b/_posts/2022-07-20-borzunov22a.md
@@ -26,7 +26,7 @@ page: 335-342
 order: 335
 cycles: false
 bibtex_author: Borzunov, Alexander and Ryabinin, Max and Dettmers, Tim and Lhoest,
-  Quentin and Saulnier, Lucile and Diskin, Michael and Jernite, Yacine
+  Quentin and Saulnier, Lucile and Diskin, Michael and Jernite, Yacine and Wolf, Thomas
 author:
 - given: Alexander
   family: Borzunov
@@ -42,6 +42,8 @@ author:
   family: Diskin
 - given: Yacine
   family: Jernite
+- given: Thomas
+  family: Wolf
 date: 2022-07-20
 address:
 container-title: Proceedings of the NeurIPS 2021 Competitions and Demonstrations Track


### PR DESCRIPTION
Somehow the name of the last author of our demonstration disappeared from the proceedings . 
Fixed it.

сс @marcociccone 