### PR TITLE
Update 2022-07-20-wei22a.md

### DIFF
--- a/_posts/2022-07-20-wei22a.md
+++ b/_posts/2022-07-20-wei22a.md
@@ -1,6 +1,6 @@
 ---
 title: '2021 BEETL Competition: Advancing Transfer Learning for Subject Independence
-  {& Heterogenous EEG Data Sets'
+  & Heterogenous EEG Data Sets'
 abstract: Transfer learning and meta-learning offer some of the most promising avenues
   to unlock the scalability of healthcare and consumer technologies driven by biosignal
   data. This is because regular machine learning methods cannot generalise well across
@@ -30,7 +30,7 @@ issn: 2640-3498
 id: wei22a
 month: 0
 tex_title: '2021 BEETL Competition: Advancing Transfer Learning for Subject Independence
-  \{&} Heterogenous EEG Data Sets'
+  & Heterogenous EEG Data Sets'
 firstpage: 205
 lastpage: 219
 page: 205-219


### PR DESCRIPTION
extra '{' before '&' marker for the title, modified to show in correct format.