### PR TITLE
Update 2022-07-20-wei22a.md

### DIFF
--- a/_posts/2022-07-20-wei22a.md
+++ b/_posts/2022-07-20-wei22a.md
@@ -30,7 +30,7 @@ issn: 2640-3498
 id: wei22a
 month: 0
 tex_title: '2021 BEETL Competition: Advancing Transfer Learning for Subject Independence
-  \& Heterogenous EEG Data Sets'
+  \{&} Heterogenous EEG Data Sets'
 firstpage: 205
 lastpage: 219
 page: 205-219


### PR DESCRIPTION
For webpage communication, the & shall be in '{' '}' to avoid network communication adding 'amp' automatically. I hope this could solve the problem.