### PR TITLE
Update 2022-07-20-wei22a.md

### DIFF
--- a/_posts/2022-07-20-wei22a.md
+++ b/_posts/2022-07-20-wei22a.md
@@ -1,6 +1,6 @@
 ---
 title: '2021 BEETL Competition: Advancing Transfer Learning for Subject Independence
-  & Heterogenous EEG Data Sets'
+  and Heterogenous EEG Data Sets'
 abstract: Transfer learning and meta-learning offer some of the most promising avenues
   to unlock the scalability of healthcare and consumer technologies driven by biosignal
   data. This is because regular machine learning methods cannot generalise well across


### PR DESCRIPTION
I noticed the '&' (and) special character problem happens in google scholar too, as '{&'. Therefore I'm changing the text title to text 'and' too.

Thanks,
Xiaoxi